### PR TITLE
Tweak boss drop delay config UI

### DIFF
--- a/MountainShrineRewardFix/Class1.cs
+++ b/MountainShrineRewardFix/Class1.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Configuration;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
@@ -43,7 +43,7 @@ namespace BossDropRewardDelay
 
             ModSettingsManager.AddOption(new SliderOption(cfgSpawnDelay, new SliderConfig()
             {
-                min = 0.2f,
+                min = 0.01f,
                 max = 4,
                 formatString = "{0:0.0}s",
             }), Guid, FormattedModName);

--- a/MountainShrineRewardFix/Class1.cs
+++ b/MountainShrineRewardFix/Class1.cs
@@ -1,4 +1,4 @@
-using BepInEx;
+﻿using BepInEx;
 using BepInEx.Configuration;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
@@ -45,7 +45,7 @@ namespace BossDropRewardDelay
             {
                 min = 0.01f,
                 max = 4,
-                formatString = "{0:0.0}s",
+                formatString = "{0:0.00}s",
             }), Guid, FormattedModName);
         }
 


### PR DESCRIPTION
This is just a small tweak on the risk of options ui. The minimum value was changed to make getting more than a thounsand items quick. And to make things easier to read it also adds one digit of precision on the config ui.